### PR TITLE
Add extraOptions to be uploaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,13 @@ var tiPush = require('ti-push-notification').init({
 // register this device
 tiPush.registerDevice({
   pnOptions: pnOptions,
-  onReceive: onReceive
+  onReceive: onReceive,
+  extraOptions: {
+    something: "a",
+    key2: true,
+    user_id: 1234,
+    whatever: "youwant"
+  }
 });
 ```
 
@@ -100,6 +106,8 @@ Your issues and pull requests are most welcome, also you can pick a task from [T
 6. Add option to depend on [CaffeinaLab GCM](https://github.com/CaffeinaLab/GCM) or [Jeroen GCM](https://github.com/morinel/gcmpush) module.
 
 ### Changelog
+**v0.1.3**<br>Add `extraOptions` parameter to be uploaded to backend too
+
 **v0.1.2**<br>Implementation changed, no need for factory, use init function directly Now module Titaniumified
 
 **v0.1.0**<br>Initialed base of [ACS Push Notifications](https://github.com/ricardoalcocer/acspushmod)

--- a/example/app.js
+++ b/example/app.js
@@ -65,5 +65,11 @@ var tiPush = require('ti-push-notification').init({
 // register this device
 tiPush.registerDevice({
   pnOptions: pnOptions,
-  onReceive: onReceive
+  onReceive: onReceive,
+  extraOptions: {
+    something: "a",
+    key2: true,
+    user_id: 1234,
+    whatever: "youwant"
+  }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti-push-notification",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Generic push notifications for both iOS and Android into Titanium apps",
   "main": "./index.js",
   "titaniumManifest": {


### PR DESCRIPTION
I have required `Alloy` and `Understore` to work with `_.each` to handle dynamic extra options that user could want it.

You could change your variables `ANDROID` and `IOS` to use alloy instead `OS_IOS`, 'OS_ANDROID'.
Thanks =)
