### PR TITLE
repair iOS check

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
  * @auther Hazem Khaled <hazem.khaled@gmail.com>
  */
 var ANDROID = Ti.Platform.name === 'android',
-  IOS = !ANDROID && (Ti.Platform.name === 'iPhone OS');
+  IOS = Ti.Platform.name === 'iPhone OS' || Ti.Platform.name === 'iOS';
 
 if (ANDROID) {
   var GCM = require("nl.vanvianen.android.gcm");


### PR DESCRIPTION
As of iOS 10, although I haven't seen it documented, `Ti.Platform.name` seems to return `iOS` instead of `iPhone OS` resulting in this module to stop working. Small fix but important ;-)
